### PR TITLE
Found a couple of typos (also changed APIS to APIs)

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,9 +187,9 @@
           <p>
             Every day, developers around the world solve this same problem, in a slightly different way. 
             And yet this is exactly what we want to avoid with the location building blocks - people solving the same problems, <i>again</i> and <i>again</i> - even if they solve them well, which is not always the case. 
-            The granular building blocks are used by the OGC APIS to address the requirements of these APIS, which are common requirements of location APIS;
+            The granular building blocks are used by the OGC APIs to address the requirements of these APIs, which are common requirements of location APIs;
             for instance: the need of a bounding box parameter or an extent data type. 
-            Next time you need to address a geo requirement in your application, instead of spending time thinking about a solution, check-out the existing location buidling blocks. 
+            Next time you need to address a geo requirement in your application, instead of spending time thinking about a solution, check-out the existing location building blocks. 
           </p>
 
 
@@ -253,7 +253,7 @@
         <div class="section-title">
           <h2>OGC APIs</h2>
           <p>Each OGC API is a bundle of modules, combined to provide a convenience API for access to a specific resource type (e.g.: feature, coverage, tile).</p>
-          <!-- <p>A "family" of web APIS, which leverage modern web practices (e.g.: REST architecture, recommended JSON encodings, OpenAPI definition)</p> -->
+          <!-- <p>A "family" of web APIs, which leverage modern web practices (e.g.: REST architecture, recommended JSON encodings, OpenAPI definition)</p> -->
         </div>
 
         <div class="row content">
@@ -491,7 +491,7 @@
               <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" class="collapse" data-bs-target="#faq-list-1">How do I know if the OGC building blocks are for me? <i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
               <div id="faq-list-1" class="collapse show" data-bs-parent=".faq-list">
                 <p>
-                  Whether you want to implement an API to access some kind of geospatial resource, or you want to spatially enable your API, you should check out the OGC building blocks. Even if you just need a small piece of functionality, the odds are this already exists. Adopting OGC building blocks also has the benefit of bringing interoperability into your application. On the other hand, if your application does not deal with geospatial data in any way,, you probably do not need the OGC building blocks.
+                  Whether you want to implement an API to access some kind of geospatial resource, or you want to spatially enable your API, you should check out the OGC building blocks. Even if you just need a small piece of functionality, the odds are this already exists. Adopting OGC building blocks also has the benefit of bringing interoperability into your application. On the other hand, if your application does not deal with geospatial data in any way, you probably do not need the OGC building blocks.
                 </p>
               </div>
             </li>
@@ -524,7 +524,7 @@
             </li>
 
             <li data-aos="fade-up" data-aos-delay="400">
-              <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">How do I know which OGC APIS/ parts of OGC APIS I need for my application?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
+              <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">How do I know which OGC APIs/ parts of OGC APIs I need for my application?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
               <div id="faq-list-5" class="collapse" data-bs-parent=".faq-list">
                 <p>
                   You can start by trying out the <a href="https://sn80uo0zmbg.typeform.com/to/gcwDDNB6" target="_blank">OGC API configurator</a>.
@@ -533,10 +533,10 @@
             </li>
 
             <li data-aos="fade-up" data-aos-delay="400">
-              <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">Do I need to read through the standards documents, in order to implement the OGC APIS building blocks?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
+              <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">Do I need to read through the standards documents, in order to implement the OGC APIs building blocks?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
               <div id="faq-list-5" class="collapse" data-bs-parent=".faq-list">
                 <p>
-                  The OGC APIS are documented using OpenAPI. In most cases, you can explore that documentation on SwaggerHub.
+                  The OGC APIs are documented using OpenAPI. In most cases, you can explore that documentation on SwaggerHub.
                 </p>
               </div>
             </li>
@@ -545,7 +545,7 @@
               <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">Who develops the building blocks?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
               <div id="faq-list-5" class="collapse" data-bs-parent=".faq-list">
                 <p>
-                  The OGC APIS are developed by their corresponding Standards Working Groups (SWG). When a SWG identifies something which has the potential to be used outside the original context of the OGC API, they incubate it as a granular building block.
+                  The OGC APIs are developed by their corresponding Standards Working Groups (SWG). When a SWG identifies something which has the potential to be used outside the original context of the OGC API, they incubate it as a granular building block.
                 </p>
               </div>
             </li>
@@ -554,7 +554,7 @@
               <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">So far, there are only a few building blocks. Can I expect more?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
               <div id="faq-list-5" class="collapse" data-bs-parent=".faq-list">
                 <p>
-                  As they evolve, It is expected that more OGC API will produce building blocks.
+                  As they evolve, it is expected that more OGC API will produce building blocks.
                 </p>
               </div>
             </li>
@@ -563,7 +563,7 @@
               <i class="bx bx-help-circle icon-help"></i> <a data-bs-toggle="collapse" data-bs-target="#faq-list-5" class="collapsed">How can I know the level of stability of a building block?<i class="bx bx-chevron-down icon-show"></i><i class="bx bx-chevron-up icon-close"></i></a>
               <div id="faq-list-5" class="collapse" data-bs-parent=".faq-list">
                 <p>
-                  Parts of OGC APIS which are published as approved standards, are expected to be stable. The most granular building blocks are published with an associated maturity level, which gives an idea of their stability.
+                  Parts of OGC APIs which are published as approved standards, are expected to be stable. The most granular building blocks are published with an associated maturity level, which gives an idea of their stability.
                 </p>
               </div>
             </li>


### PR DESCRIPTION
 Changed APIS to APIs to be consistent with the menu and most other uses around the web[https://en.wikipedia.org/wiki/API; https://developer.chrome.com/docs/apps/api_other/]
 
 If you have a strong reason to keep APIS as is, you should still accept the other changes.